### PR TITLE
37764 return ods processor schema info

### DIFF
--- a/src/main/java/GeoSpatialConverter/geoSpatialConverter.java
+++ b/src/main/java/GeoSpatialConverter/geoSpatialConverter.java
@@ -119,9 +119,17 @@ public class geoSpatialConverter
     @RequestMapping(value = API_PREFIX + "/health", method = RequestMethod.GET)
     public ResponseEntity<String> getHealthCheck() throws Exception
     {
-        String resultStr = "I'm doing science and I'm still alive.";
+        // Initialized return values for ODS structure.
+        String statusStr = "I'm doing science and I'm still alive.";
+        Boolean includeLastUpdated = true;
+
+        // Create object to store return and make the call
+        JSONObject jsonReturnObj = new JSONObject();
+        jsonReturnObj.put("ODS", odsProcessorUtilities.getOdsProcessorJson(statusStr, includeLastUpdated));
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setContentType(MediaType.TEXT_PLAIN);
-        return new ResponseEntity<String> (resultStr, httpHeaders, HttpStatus.OK);
+
+        // Prepare return
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        return new ResponseEntity<String> (jsonReturnObj.toString(), httpHeaders, HttpStatus.OK);
     }
 }

--- a/src/main/java/GeoSpatialConverter/geoSpatialConverter.java
+++ b/src/main/java/GeoSpatialConverter/geoSpatialConverter.java
@@ -15,24 +15,27 @@ import mil.nga.ods.geotrans.GeoTransMaster;
 
 @RestController
 public class geoSpatialConverter
-{   
+{
     private GeoTransMaster geoTransMaster = new GeoTransMaster();
     private static final String API_PREFIX = "/v2/ods/coordinateConversion";
-    
+
     @RequestMapping(value = API_PREFIX + "/doConversion", method = RequestMethod.POST)
     public ResponseEntity<String> doConversionPost(@RequestBody String jsonStr)
     {
         try
         {
-            JSONObject jsonObj = new JSONObject(jsonStr);
-            String jsonResultStr = geoTransMaster.doConversion(jsonObj.toString()).toString();
+            //JSONObject jsonObj = new JSONObject(jsonStr);
+            //String jsonResultStr = geoTransMaster.doConversion(jsonObj.toString()).toString();
+            JSONObject jsonRequestObj = new JSONObject(jsonStr);
+            JSONObject jsonReturnObj = geoTransMaster.doConversion(jsonRequestObj.toString());
+            jsonReturnObj.put("ODS", odsProcessorUtilities.getOdsProcessorJson("success"));
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-            return new ResponseEntity<String> (jsonResultStr, httpHeaders, HttpStatus.OK);
+            return new ResponseEntity<String> (jsonReturnObj.toString(), httpHeaders, HttpStatus.OK);
         }
          catch (JSONException ex)
         {
-        	 return new ResponseEntity<String> (ex.toString(), HttpStatus.BAD_REQUEST);
+             return new ResponseEntity<String> (ex.toString(), HttpStatus.BAD_REQUEST);
         }
         catch (Exception e)
         {
@@ -40,7 +43,6 @@ public class geoSpatialConverter
             e.printStackTrace();
             return new ResponseEntity<String> (e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
-       
     }
 
     @RequestMapping(value = API_PREFIX + "/doTranslation", method = RequestMethod.POST)
@@ -48,15 +50,18 @@ public class geoSpatialConverter
     {
         try
         {
-            JSONObject jsonObj = new JSONObject(jsonStr);
-            String jsonResultStr = geoTransMaster.doCoordinateTranslation(jsonObj.toString()).toString();
+            //JSONObject jsonObj = new JSONObject(jsonStr);
+            //String jsonResultStr = geoTransMaster.doCoordinateTranslation(jsonObj.toString()).toString();
+            JSONObject jsonRequestObj = new JSONObject(jsonStr);
+            JSONObject jsonReturnObj = geoTransMaster.doCoordinateTranslation(jsonRequestObj.toString());
+            jsonReturnObj.put("ODS", odsProcessorUtilities.getOdsProcessorJson("success"));
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-            return new ResponseEntity<String> (jsonResultStr, httpHeaders, HttpStatus.OK);
+            return new ResponseEntity<String> (jsonReturnObj.toString(), httpHeaders, HttpStatus.OK);
         }
          catch (JSONException ex)
         {
-        	 return new ResponseEntity<String> (ex.toString(), HttpStatus.BAD_REQUEST);
+             return new ResponseEntity<String> (ex.toString(), HttpStatus.BAD_REQUEST);
         }
         catch (Exception e)
         {

--- a/src/main/java/GeoSpatialConverter/odsProcessorUtilities.java
+++ b/src/main/java/GeoSpatialConverter/odsProcessorUtilities.java
@@ -1,0 +1,50 @@
+package GeoSpatialConverter;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class odsProcessorUtilities
+{
+    private static final String ODS_PROCESSOR_NAME = "coordinateConversion";
+    private static final String ODS_PROCESSOR_VERSION = "2.0.0";
+
+    /**
+     * Method for generating JSON object that contains the values required for .
+     * filling out the ODS.processor structure for the EMC return by the calling
+     * service.
+     * 
+     * @return JSONObject containing array result of ODS processor information.
+     * @throws JSONException
+     * @since ODS sprint 10.2
+     */
+    public static JSONObject getOdsProcessorJson(String status) throws JSONException
+    {
+        JSONObject processorJSON = new JSONObject();  // Store processor information
+        JSONObject processorsJSON = new JSONObject();  // Store processors
+        JSONObject odsJSON = new JSONObject();
+        
+        processorJSON.put("status", status);
+        processorJSON.put("timestamp", getEMCTimestamp());
+        processorJSON.put("version", ODS_PROCESSOR_VERSION);
+        
+        processorsJSON.put(ODS_PROCESSOR_NAME, processorJSON);
+        odsJSON.put("Processors", processorsJSON);
+        
+        return odsJSON;
+    }
+
+    private static String getEMCTimestamp()
+    {
+        return ZonedDateTime                // Represent a moment as perceived in the wall-clock time used by the people of a particular region ( a time zone).
+                .now(                       // Capture the current moment.
+                        ZoneId.of( "UTC" )  // Specify the time zone using proper Continent/Region name. Never use 3-4 character pseudo-zones such as PDT, EST, IST. 
+                    )                       // Returns a `ZonedDateTime` object. 
+                    .format(                // Generate a `String` object containing text representing the value of our date-time object. 
+                        DateTimeFormatter.ofPattern( "uuuu-MM-dd'T'HH:mm:ss.SSSxxx" )  // Meet the example EMC field requirement 2018-05-24T16:36:32.937+00:00
+                    );
+    }
+}

--- a/src/main/java/GeoSpatialConverter/odsProcessorUtilities.java
+++ b/src/main/java/GeoSpatialConverter/odsProcessorUtilities.java
@@ -3,14 +3,22 @@ package GeoSpatialConverter;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
 public class odsProcessorUtilities
 {
-    private static final String ODS_PROCESSOR_NAME = "coordinateConversion";
-    private static final String ODS_PROCESSOR_VERSION = "2.0.0";
+    // Config file to read properties from
+    private static final String CONFIG_FILE_NAME = "config.properties";
+    // Back up values in case config file can't be read.
+    private static final String ODS_PROCESSOR_NAME = "default_name";
+    private static final String ODS_PROCESSOR_VERSION = "default_version";
+    private static final String ODS_PROCESSOR_LAST_UPDATED = "default_timestamp";
 
     /**
      * Method for generating JSON object that contains the values required for .
@@ -21,20 +29,35 @@ public class odsProcessorUtilities
      * @throws JSONException
      * @since ODS sprint 10.2
      */
-    public static JSONObject getOdsProcessorJson(String status) throws JSONException
+    public static JSONObject getOdsProcessorJson(String status, Boolean includeLastUpdated) throws JSONException
     {
         JSONObject processorJSON = new JSONObject();  // Store processor information
         JSONObject processorsJSON = new JSONObject();  // Store processors
         JSONObject odsJSON = new JSONObject();
-        
+
+        Properties properties = getConfigProperties(CONFIG_FILE_NAME);
+
+        // Get values from properties if they exist, or use defaults
+        String processorName = (properties.containsKey("ODS_PROCESSOR_NAME")) ? properties.getProperty("ODS_PROCESSOR_NAME") : ODS_PROCESSOR_NAME;
+        String processorVersion = (properties.containsKey("ODS_PROCESSOR_VERSION")) ? properties.getProperty("ODS_PROCESSOR_VERSION") : ODS_PROCESSOR_VERSION;
+        String processorLastUpdated = (properties.containsKey("ODS_PROCESSOR_LAST_UPDATED")) ? properties.getProperty("ODS_PROCESSOR_LAST_UPDATED") : ODS_PROCESSOR_LAST_UPDATED;
+
         processorJSON.put("status", status);
         processorJSON.put("timestamp", getEMCTimestamp());
-        processorJSON.put("version", ODS_PROCESSOR_VERSION);
-        
-        processorsJSON.put(ODS_PROCESSOR_NAME, processorJSON);
+        processorJSON.put("version", processorVersion);
+        if (includeLastUpdated)
+        {
+            processorJSON.put("lastUpdated", processorLastUpdated);
+        }
+
+        processorsJSON.put(processorName, processorJSON);
         odsJSON.put("Processors", processorsJSON);
-        
+
         return odsJSON;
+    }
+    public static JSONObject getOdsProcessorJson(String status) throws JSONException
+    {
+        return getOdsProcessorJson(status, false);
     }
 
     private static String getEMCTimestamp()
@@ -46,5 +69,44 @@ public class odsProcessorUtilities
                     .format(                // Generate a `String` object containing text representing the value of our date-time object. 
                         DateTimeFormatter.ofPattern( "uuuu-MM-dd'T'HH:mm:ss.SSSxxx" )  // Meet the example EMC field requirement 2018-05-24T16:36:32.937+00:00
                     );
+    }
+
+    private static Properties getConfigProperties(String propertiesFile)
+    {
+        Properties prop = new Properties();
+        InputStream input = null;
+
+        try
+        {
+            input = odsProcessorUtilities.class.getClassLoader().getResourceAsStream(propertiesFile);
+            if(input==null)
+            {
+                System.out.println("Sorry, unable to find " + propertiesFile);
+                return prop;
+            }
+
+            //load a properties file from class path, inside static method
+            prop.load(input);
+        }
+        catch (IOException ex)
+        {
+            ex.printStackTrace();
+        }
+        finally
+        {
+            if(input!=null)
+            {
+                try
+                {
+                    input.close();
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        return prop;
     }
 }

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,4 @@
+# Properties for ODS schema values to be used in JSON return
+ODS_PROCESSOR_NAME=coordinateConversion
+ODS_PROCESSOR_VERSION=2.0.0
+ODS_PROCESSOR_LAST_UPDATED=2019-02-22T19:28:33.062+00:00


### PR DESCRIPTION
Added utility class and methods to generate the ODS.Processors JSON structure required to update the EMC with which processors ran against the data.  Will be consumed by Geospatial Conditioning service.

Example EMC schema structure for ODS section:
"ODS": {
         "Processors": {
            "<service_name>": {
                "version": "ods_keyword",
                "status": "ods_keyword",
                "timestamp": "ods_date"
            },
        }
    }